### PR TITLE
fix: correlation template error when creating a revision using kubectl

### DIFF
--- a/pkg/controllers/devicetemplate/deploy/example_template.yaml
+++ b/pkg/controllers/devicetemplate/deploy/example_template.yaml
@@ -10,6 +10,5 @@ spec:
   deviceResource: modbusdevices
   labels:
     foo: bar
-  displayName: my-modbus-template
-  description: template example
-  defaultRevisionName: ''
+  defaultRevisionName: ""
+  description: "template example"

--- a/pkg/controllers/devicetemplaterevision/deploy/example_template_revision.yaml
+++ b/pkg/controllers/devicetemplaterevision/deploy/example_template_revision.yaml
@@ -1,6 +1,7 @@
 apiVersion: edgeapi.cattle.io/v1alpha1
 kind: DeviceTemplateRevision
 metadata:
+  name: v1
   namespace: default
 spec:
   displayName: v1


### PR DESCRIPTION
Problem:
When a user creates a revision using kubectl instead of through the api interface, it causes the defaultrevisioname field of the template structure that this revision wants to be associated with to be unmodified.