### PR TITLE
fix invalid generated token name

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -80,9 +80,13 @@ func GetJWTSecretTokenName(token string) (string, error) {
 	if err != nil {
 		return name, err
 	}
-	name = strings.Trim(strings.ToLower(parts[2]), "_")
-	name = name[len(name)-nameLength:]
-	return fmt.Sprintf("jwt-%s-secret", name), nil
+	splitToken := strings.ToLower(parts[2])
+	if splitToken != "" && len(splitToken) >= nameLength {
+		name = strings.Replace(splitToken, "_", "-", -1)
+		name = name[len(name)-nameLength:]
+		return fmt.Sprintf("jwt-%s-secret", name), nil
+	}
+	return name, fmt.Errorf("failed to generate token name by JWT token, invalid length %d", len(parts[2]))
 }
 
 func SplitJWTTokenParts(token string) ([]string, error) {


### PR DESCRIPTION
Problem: need to fix invalid generated token name
```
Token Signing error: Secret \"jwt-suo_ures-secret\" is invalid: metadata.name: Invalid value: \"jwt-suo_ures-secret\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')\n
```

Solution: need to use replace instead of trim