### PR TITLE
fix:Default access to local ui when packaged as a specific version in…

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -20,6 +20,7 @@ DEFAULT_VALUES="{\"ui-index\":\"${UI_INDEX}\"}"
 
 LINKFLAGS="-X github.com/cnrancher/octopus-api-server.Version=$VERSION"
 LINKFLAGS="-X github.com/cnrancher/octopus-api-server.GitCommit=$COMMIT $LINKFLAGS"
+LINKFLAGS="-X github.com/cnrancher/octopus-api-server/pkg/settings.InjectDefaults=$DEFAULT_VALUES $LINKFLAGS"
 CGO_ENABLED=0 go build -ldflags "$LINKFLAGS $OTHER_LINKFLAGS" -o bin/octopus-api-server
 if [ "$CROSS" = "true" ] && [ "$ARCH" = "amd64" ]; then
     GOOS=darwin go build -ldflags "$LINKFLAGS" -o bin/octopus-api-server-darwin


### PR DESCRIPTION
Problem:
Default access to local UI when packaged as a specific version instead of master
Solution:
In the go build compile, if it is a specific version and not the master,set the InjectDefaults global variable in the settings package to "{\"ui-index\":\"local"}" 